### PR TITLE
Directories made with 755 permissions

### DIFF
--- a/src/Utils/FileUtils.php
+++ b/src/Utils/FileUtils.php
@@ -57,7 +57,7 @@ class FileUtils
      *
      * @return bool
      */
-    public static function mkdir($path, $mode = 0644)
+    public static function mkdir($path, $mode = 0755)
     {
         $filesystem = new Filesystem();
 
@@ -137,7 +137,7 @@ class FileUtils
         $dir = dirname($filename);
 
         if (!is_dir($dir)) {
-            self::mkdir($dir, 0644);
+            self::mkdir($dir, 0755);
         } elseif (!is_writable($dir)) {
             return false;
         }


### PR DESCRIPTION
Directories when created should be made with the executable bit, so should be made with 755 permissions

I was getting permissions issues in my PR browscap/browscap-php#62 because the directories created by this were not writeable once created.
